### PR TITLE
prevent the #zc_header from being added infinitely

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ It also contains HTML/CSS/JS that was from the official site, slightly modified 
 ```
 brew install http-server
 git clone git@github.com:Justin-Credible/picobrew-recipes.git
-cd picobrew-recipes
+cd picobrew-recipes/www
 http-server
 ```

--- a/www/recipe.html
+++ b/www/recipe.html
@@ -24,8 +24,8 @@
 
     <!-- Hack so the sticky header doesn't overlay the top content -->
     <style>
-        .rv--h-c {
-            margin-top: 10rem;
+        .main-content {
+            margin-top: 5rem;
         }
     </style>
 
@@ -36,10 +36,10 @@
     <div id="main-internal-wrapper">
         <header id="header" class="noprint">
             <!-- Original navigation header (hidden) -->
-            <nav id="pico-nav-app" navitems="[]" passedusername="" style="display: none;">
+            <!-- <nav id="pico-nav-app" navitems="[]" passedusername="" style="display: none;">
                 <pico-nav :vm="vm" :promovm="promovm" :promoactive="promoactive" v-on:nav-link-event="handleNavLinkEvent"></pico-nav>
                 <div style="width:100%;" :style="padStyle"></div>
-            </nav>
+            </nav> -->
             <!-- Hardcoded navigation header -->
             <nav>
                 <div class="pico-nav--wrap">
@@ -96,11 +96,11 @@
                         </div>
                     </div>
 
-                    <div class="col-xs-12 text-center" v-if="!loaded">
+                    <div class="col-xs-12 text-center main-content" v-if="!loaded">
                         <br />
                         <h4><i class="fa fa-spinner fa-spin"></i> Loading Recipe...</h4>
                     </div>
-                    <div v-else>
+                    <div class="main-content" v-else>
                         <h1 style="color: #f94a4a; text-align: center" v-if="vm.AdminView">ADMIN VIEW - DO NOT MODIFY</h1>
                         <!-- Options -->
                         <div class="text-center" id="all"></div> <!-- Errors -->
@@ -121,10 +121,10 @@
                             <div class="l-button-div" v-if="vm.OwnedByUser && !IsPublic && false">
                                 <a href="#" data-toggle="modal" data-target="#deleterecipe">Delete</a>
                             </div>
-                            <div class="l-button-div">
+                            <div class="l-button-div" v-if="false">
                                 <a href='#' v-on:click="false ? printRecipe() : showLoginModal()">Print</a>
                             </div>
-                            <div class="l-button-div" v-if="(!vm.OwnedByUser && IsPublic && !(!vm.Recipe.Locked && false)) || !false">
+                            <div class="l-button-div" v-if="(!vm.OwnedByUser && IsPublic && !(!vm.Recipe.Locked && false)) && false">
                                 <a href='#' v-on:click="false ? copyRecipe() : showLoginModal()">Copy to My Brewhouse</a>
                             </div>
                             <div class="l-button-div" v-if="false">


### PR DESCRIPTION
Since there are two different .pico-nav elements in the page source (original one simply hidden) the jquery method `$el.insertAfter($target)` will duplicate the `$el` and add it to each available $target nodes that isn't the original `$el` in the document.

This lead to the sticky header upon adding to not be able to be "removed" simply by removing the class `.zc_sticky_header` from it... 

**Before**
scrolling down to the bottom and back up produces several copies of the intended sticky header which is to show when the user scrolls the recipe stats out of view though persists at the top of the experience for ever once it appears
![image](https://user-images.githubusercontent.com/2158627/145719119-3fd46a5e-f7ca-4bfb-b24c-66af5eafc550.png)
![image](https://user-images.githubusercontent.com/2158627/145719253-aafc3dae-7922-4123-9b5a-cba664d93522.png)

**After**
expected behavior, there is only one element of `#zc_header` regardless of amount the user scrolls
![image](https://user-images.githubusercontent.com/2158627/145719215-2e160bdf-bfef-4cdb-9a3b-c85c4f99c0ca.png)
before and after the sticky stats header appears with the fixed code
![image](https://user-images.githubusercontent.com/2158627/145719277-2ea09a00-60cf-4f0a-93dd-6ecb11d06384.png)
