### PR TITLE
use modern browser support for natively parsing query parameters

### DIFF
--- a/www/assets/js/recipes/page-loader.js
+++ b/www/assets/js/recipes/page-loader.js
@@ -5,9 +5,8 @@
 
     var element = document.getElementById("recipe-vm-app");
 
-    var queryString = document.location.search;
-
-    var id = queryString.split("=")[1];
+    const params = new URLSearchParams(location.search);
+    const id = params.get("id");
 
     element.setAttribute("recipeguid", id);
     element.setAttribute("api", "/data/recipes/" + id + ".json");


### PR DESCRIPTION
Details are within a thread on the Picobrewers facebook group between myself and Patrick on debugging why when clicking a link from Facebook wouldn't render.

Example of what doesn't work (shows a spinner): https://pbrecipes.beer/recipe.html?id=a37ad562c49046709edf4be9cc6a4ac0&second=parameter-incorrectly-parses-due-to-parsing-logic

According to https://caniuse.com/?search=URLSearchParams I believe most up to date browsers support the `URLSearchParams` API so we can rely on this. If people report issues we may need to make a shim to work around that.... but most should be using modern enough browsers these days.